### PR TITLE
linux.d/debian: use correct string match syntax

### DIFF
--- a/linux.d/debian
+++ b/linux.d/debian
@@ -36,10 +36,10 @@ if [[ -n "$UPDATE_LIB" ]]
 then
     # for ubuntu 22+ and 23+:
     ubu_major_version="$(grep VERSION_ID /etc/os-release | cut -d "=" -f 2 | cut -d "." -f 1 | tr -d /\"/)"
-    if [ $ubu_major_version == "22" ] || [ $ubu_major_version == "23" ]
+    if [ $ubu_major_version = "22" ] || [ $ubu_major_version = "23" ]
     then
         REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.0-dev curl libfuse-dev libssl-dev libcurl4-openssl-dev m4)
-    elif [ $ubu_major_version == "24" ]
+    elif [ $ubu_major_version = "24" ]
     then
         REQUIRED_DEV_PACKAGES+=(libwebkit2gtk-4.1-dev)
     else


### PR DESCRIPTION
The test(1) command (also known as '[') does not use the '==' syntax for testing equality, which is a
feature of bash's '[[' builtin. String equality
is tested with '=', and numeric equality with '-eq'. This eliminates a series of warnings when running
BuildLinux.sh on Debian-derived systems:

[schwarzgerat](0) $ ./BuildLinux.sh -u
./linux.d/debian: line 39: [: ==: unary operator expected ./linux.d/debian: line 39: [: ==: unary operator expected ./linux.d/debian: line 42: [: ==: unary operator expected